### PR TITLE
Outplace crossover

### DIFF
--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/launch/RunOptimisation.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/launch/RunOptimisation.xtend
@@ -56,11 +56,10 @@ class RunOptimisation {
 				val resource = resourceSetProvider.get().getResource(URI.createFileURI(moptFile.getAbsolutePath()), true)
 				val optimisationModel = resource.contents.head as Optimisation
 				
-				val mdeoResultsOutput = new MDEOResultsOutput(new Date(), new Path(moptProjectPath), 
-					new Path(configuredMoptFilePath), optimisationModel
-				);	
-				
 				if(optimisationModel !== null){
+										
+					val mdeoResultsOutput = new MDEOResultsOutput(new Date(), new Path(moptProjectPath), 
+						new Path(configuredMoptFilePath), optimisationModel);
 					
 					var experimentId = 0;
 	            	do {	

--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
@@ -1,25 +1,24 @@
 package uk.ac.kcl.ui.output
 
-import java.util.Date
-import java.util.List
-import java.util.LinkedList
-import org.eclipse.emf.ecore.resource.ResourceSet
-import uk.ac.kcl.mdeoptimise.Optimisation
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
-import org.eclipse.emf.ecore.EObject
-import java.util.Collections
-import java.text.SimpleDateFormat
-import uk.ac.kcl.optimisation.moea.MoeaOptimisationSolution
-import java.io.PrintWriter
-import java.io.File
-import org.eclipse.emf.common.util.URI
-import org.eclipse.core.runtime.IPath
-import java.util.TimeZone
-import java.util.HashMap
 import com.google.common.io.Files
+import java.io.File
+import java.io.PrintWriter
 import java.nio.charset.Charset
-import org.eclipse.emf.ecore.xmi.XMIResource
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.HashMap
+import java.util.LinkedList
+import java.util.List
 import java.util.Map
+import java.util.TimeZone
+import org.eclipse.core.runtime.IPath
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.emf.ecore.xmi.XMIResource
+import uk.ac.kcl.mdeoptimise.Optimisation
+import uk.ac.kcl.optimisation.moea.MoeaOptimisationSolution
 
 class MDEOResultsOutput {
 	
@@ -44,7 +43,7 @@ class MDEOResultsOutput {
 		batches.add(batch);
 	}
 	
-	def String outputBatchSummary(MDEOBatch batch, IPath outcomePath) {
+	def String outputBatchSummary(MDEOBatch batch, IPath outcomePath, IPath metaModelOutputPath) {
 		var batchOutputPath = outcomePath.append(String.format("batch-%s/", batch.id))
 		var batchInfoPath = batchOutputPath.append("outcome.txt")
 		
@@ -71,7 +70,7 @@ class MDEOResultsOutput {
 			val solution = batch.solutions.get(i);
 			val modelPath = batchOutputPath + String.format("%08X", solution.model.hashCode) + ".xmi"
 			
-			solution.model.writeModel(modelPath)
+			solution.model.writeModel(modelPath, metaModelOutputPath.toPortableString)
 			storeSolutionData(batchWriter, modelPath, solution)
 		}
 		
@@ -132,25 +131,42 @@ class MDEOResultsOutput {
 		}
 	}
 	
+	def IPath copyMetaModel(IPath outcomePath){
+		val metaModelInputPath = projectRoot.append(moptConfiguration.basepath.location).append(moptConfiguration.metamodel.location)
+		val metaModelOutputPath = outcomePath.append(metaModelInputPath.lastSegment)
+		
+		if (!metaModelInputPath.empty) {
+			val outputFile = metaModelOutputPath.toFile
+			Files.createParentDirs(outputFile)
+			Files.copy(metaModelInputPath.toFile, outputFile)
+		}
+		return metaModelOutputPath
+	}
+	
 	def void saveOutcome(){
 		
 		val experimentDate = new SimpleDateFormat("yyMMdd-HHmmss").format(experimentStartTime);
 		val outcomePath = projectRoot.append(String.format("mdeo-results/experiment-%s/", experimentDate));
+				
+		val metaModelOutputPath = copyMetaModel(outcomePath)
 		
 		val batchesOutput = new StringBuilder();
 		
-		batches.forEach[ batch | batchesOutput.append(outputBatchSummary(batch, outcomePath))]
+		batches.forEach[ batch | batchesOutput.append(outputBatchSummary(batch, outcomePath, metaModelOutputPath))]
 		
 		outputExperimentSummary(batches, outcomePath, moptFile, batchesOutput)
 	}
 	
-	def writeModel(EObject model, String path) {
-		val resource = resourceSet.createResource(URI.createFileURI(path))
+	def writeModel(EObject model, String path, String metaModelPath) {
+		val resource = resourceSet.createResource(URI.createFileURI(new File(path).absolutePath))
 		if (resource.loaded) {
 			resource.contents.clear
 		}
 		resource.contents.add(model)
 		
+		// Change URI of model package to reference the meta model copied to output location
+		model.eClass.EPackage.eResource.URI = URI.createFileURI(metaModelPath)
+				
 		// Keep schema location in output models
 		val Map<Object,Object> options = new HashMap<Object,Object>();
 		options.put(XMIResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);

--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
@@ -18,6 +18,8 @@ import java.util.TimeZone
 import java.util.HashMap
 import com.google.common.io.Files
 import java.nio.charset.Charset
+import org.eclipse.emf.ecore.xmi.XMIResource
+import java.util.Map
 
 class MDEOResultsOutput {
 	
@@ -148,7 +150,12 @@ class MDEOResultsOutput {
 			resource.contents.clear
 		}
 		resource.contents.add(model)
-		resource.save(Collections.EMPTY_MAP)
+		
+		// Keep schema location in output models
+		val Map<Object,Object> options = new HashMap<Object,Object>();
+		options.put(XMIResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
+		
+		resource.save(options)
 	}
 
 	private def storeSolutionData(PrintWriter infoWriter, String modelPath, MoeaOptimisationSolution solution){

--- a/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/moea/MoeaProbabilisticVariation.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/moea/MoeaProbabilisticVariation.xtend
@@ -45,20 +45,18 @@ class MoeaProbabilisticVariation implements Variation {
 			println("Not running crossover this run")
 		}
 		
-		var solutions = new LinkedList<Solution>();
-		
 		for(var i = 0; i < result.length; i++){
 			
 			var mutationProbability = random.nextDouble
 			if(mutationProbability <= mutationRate){
 				println("Running mutation with probability: " + mutationProbability)
-				solutions.addAll(mutationOperator.evolve(#[result.get(i)]))
+				result.set(i, mutationOperator.evolve(#[result.get(i)]).get(0))
 			} else {
 				println("Not running mutation this run")
 			}
 		}
 		
-		return solutions;	
+		return result;
 
 	}
 	


### PR DESCRIPTION
Changed the inplace crossover used in SolutionGenerator to a outplace version. 
This implies each crossover operator needs to be applied twice for each pair of parents as well as a fixed arity of 2. Additionally, a contract is needed specifying which of the parents will be used as the result of each step. Currently, the second parent is used as result which follows the idea of parent1 being the source and parent2 being the target of the crossover operator.

Maybe, this should be pulled to an alternative branch?