### PR TITLE
allow m2e to recognize xtext-gen folders as source folders as specifi…

### DIFF
--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -147,6 +147,23 @@
     								<ignore></ignore>
     							</action>
     						</pluginExecution>
+							<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>
+    									com.coveo
+    								</groupId>
+    								<artifactId>
+    									fmt-maven-plugin
+    								</artifactId>
+    								<versionRange>[2.8,)</versionRange>
+    								<goals>
+    									<goal>format</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
     					</pluginExecutions>
     				</lifecycleMappingMetadata>
     			</configuration>

--- a/languages/mopt/xtext/pom.xml
+++ b/languages/mopt/xtext/pom.xml
@@ -167,9 +167,7 @@
 										</versionRange>
 										<goals>
 											<goal>add-resource</goal>
-											<goal>add-source</goal>
 											<goal>add-test-resource</goal>
-											<goal>add-test-source</goal>
 										</goals>
 									</pluginExecutionFilter>
 									<action>


### PR DESCRIPTION
…ed by build-helper-maven-plugin for mdeo xtext plugin; ignore fmt-maven-plugin in m2e

Ignoring fmt-maven-plugin should be no problem. Worst case, the code is not formatted correctly and the next command line build or manual execution of the plugin will fix it. In my opinion, better than letting Eclipse people find out what's going on by themselves.

For the MDEO xtext plugin I removed the part of the lifecycle mapping which ignored the add-source, add-test-source goals of build-helper-maven-plugin. I am not sure why those ignores were added. At least in current versions of m2e there is a dedicated connector for the build-helper-plugin which should be installed. Otherwise, the generated xtext-gen folders are not added as source folders in Eclipse which causes a myriad of errors after import.

I will send a proposal for the Developers Instructions of github.io taking those changes into account.