### PR TITLE
added windows specific targets for exec tasks, adapted windows specif…

### DIFF
--- a/build/maven/build.xml
+++ b/build/maven/build.xml
@@ -2,11 +2,23 @@
 <project name="mopt.xtext" default="default">
     <import file="../ant/build-common.xml"/>
 
+	<condition property="isWindows">
+		<os family="windows" />
+	</condition>
 
+    <target name="dist" depends="render.maven.properties.template, maven.build, maven.build.windows"/>
 
-    <target name="dist" depends="render.maven.properties.template, maven.build"/>
-
-    <target name="maven.build">
+    <target name="maven.build.windows" if="isWindows">
+        <exec dir="." executable="cmd" failifexecutionfails="true" failonerror="true">
+			<arg value="/c"/>
+			<arg value="mvn"/>
+            <arg value="clean" />
+            <arg value="deploy" />
+            <arg value="--quiet" />
+        </exec>
+    </target>
+	
+	<target name="maven.build" unless="isWindows">
         <exec dir="." executable="mvn" failifexecutionfails="true" failonerror="true">
             <arg value="clean" />
             <arg value="deploy" />
@@ -16,27 +28,39 @@
 
 
     <!-- Load current build version http://llbit.se/?p=1876 -->
-
-    <target name="load-build-version">
-
+	
+	<target name="load-build-version.windows" if="isWindows">
       <echo message="Updating version string from Git"/>
+      <exec executable="cmd" outputproperty="ant.build.branch"
+              failifexecutionfails="true">
+			  <arg value="/c"/>
+			  <arg value="git"/>
+              <arg value="rev-parse"/>
+              <arg value="--short"/>
+              <arg value="HEAD" />
+      </exec>
+    </target>
+
+    <target name="load-build-version" unless="isWindows">
+      <echo message="Updating version string from Git"/>	  
       <exec executable="git" outputproperty="ant.build.branch"
               failifexecutionfails="true">
               <arg value="rev-parse"/>
               <arg value="--short"/>
               <arg value="HEAD" />
       </exec>
+	</target>
 
+	<target name="load-build-version-set-time" depends="load-build-version.windows, load-build-version">
       <echo message="Loading current timestamp"/>
       <tstamp>
           <format property="ant.build.timestamp" pattern="yyyy.MM.dd.HHmmss"/>
       </tstamp>
-
     </target>
 
     <!-- Render target file from a template to point to the local maven repository -->
 
-    <target name="render.maven.properties.template" depends="load-build-version">
+    <target name="render.maven.properties.template" depends="load-build-version-set-time">
 
         <!-- Copy task that replaces values and copies the files -->
         <copy todir="./" verbose="true" overwrite="true" failonerror="true">

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="dependencies" default="depend.all">
-    <dirname property="dependencies.basedir" file="${ant.file.dependencies}"/>
+    
+	<condition property="isWindows">
+		<os family="windows" />
+	</condition>
+	
+	<target name="windows.directory.format" if="isWindows">
+		<dirname property="dependencies.basedir.windows" file="${ant.file.dependencies}"/>
+        <path id="dependencies.basedir.path">
+			<pathelement path="${dependencies.basedir.windows}" />
+		</path>
+		<pathconvert targetos="unix" property="dependencies.basedir" refid="dependencies.basedir.path"/>
+    </target>
+	
+	<target name="unix.directory.format" unless="isWindows">
+	     <dirname property="dependencies.basedir" file="${ant.file.dependencies}"/>
+    </target>
 
     <!-- ================================================================== -->
     <target name="depend.all" depends="depend.maven, depend.eclipse">
@@ -8,7 +23,7 @@
 
     <!-- Maven Builds -->
     <!-- ================================================================== -->
-    <target name="depend.maven">
+    <target name="depend.maven" depends="windows.directory.format, unix.directory.format">
             <ant dir="${dependencies.basedir}/build/maven" inheritAll="true"/>
     </target>
 

--- a/interfaces/eclipse/build.xml
+++ b/interfaces/eclipse/build.xml
@@ -2,11 +2,29 @@
 <project name="mopt.xtext" default="default">
     <import file="../../build/ant/build-common.xml"/>
 
+	<condition property="isWindows">
+		<os family="windows" />
+	</condition>
 
+    <target name="dist" depends="maven.build, maven.build.windows"/>
+	
+	<target name="maven.build.windows" depends="render.target.template" if="isWindows">
+        <exec dir="." executable="cmd" failifexecutionfails="true" failonerror="true">
+			<arg value="/c"/>
+			<arg value="mvn"/>
+            <arg value="-f" />
+            <arg value="src/pom.xml"/>
+            <arg value="clean" />
+            <arg value="install" />
+            <arg value="--quiet" />
+            <arg value="-Dmaven.wagon.http.ssl.insecure=true" />
+            <arg value="-Dmaven.wagon.http.ssl.allowall=true" /> 
+            <arg value="-Dmaven.wagon.http.ssl.ignore.validity.dates=true" />
+            
+        </exec>
+    </target>
 
-    <target name="dist" depends="maven.build"/>
-
-    <target name="maven.build" depends="render.target.template">
+    <target name="maven.build" depends="render.target.template" unless="isWindows">
         <exec dir="." executable="mvn" failifexecutionfails="true" failonerror="true">
             <arg value="-f" />
             <arg value="src/pom.xml"/>


### PR DESCRIPTION
…ic path to contain forward slashes

Finally, an adaption of the build config which should work for unix and windows. I am getting tired of merging the fix into my local branches.

It's a bit verbose but so is ant in general, I guess. At least it works. As I don't have a unix machine ready maybe someone could double check if the build still works flawless there as well.