### PR TITLE
Outplace crossover

### DIFF
--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/launch/RunOptimisation.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/launch/RunOptimisation.xtend
@@ -56,11 +56,10 @@ class RunOptimisation {
 				val resource = resourceSetProvider.get().getResource(URI.createFileURI(moptFile.getAbsolutePath()), true)
 				val optimisationModel = resource.contents.head as Optimisation
 				
-				val mdeoResultsOutput = new MDEOResultsOutput(new Date(), new Path(moptProjectPath), 
-					new Path(configuredMoptFilePath), optimisationModel
-				);	
-				
 				if(optimisationModel !== null){
+										
+					val mdeoResultsOutput = new MDEOResultsOutput(new Date(), new Path(moptProjectPath), 
+						new Path(configuredMoptFilePath), optimisationModel);
 					
 					var experimentId = 0;
 	            	do {	

--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
@@ -1,25 +1,24 @@
 package uk.ac.kcl.ui.output
 
-import java.util.Date
-import java.util.List
-import java.util.LinkedList
-import org.eclipse.emf.ecore.resource.ResourceSet
-import uk.ac.kcl.mdeoptimise.Optimisation
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
-import org.eclipse.emf.ecore.EObject
-import java.util.Collections
-import java.text.SimpleDateFormat
-import uk.ac.kcl.optimisation.moea.MoeaOptimisationSolution
-import java.io.PrintWriter
-import java.io.File
-import org.eclipse.emf.common.util.URI
-import org.eclipse.core.runtime.IPath
-import java.util.TimeZone
-import java.util.HashMap
 import com.google.common.io.Files
+import java.io.File
+import java.io.PrintWriter
 import java.nio.charset.Charset
-import org.eclipse.emf.ecore.xmi.XMIResource
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.HashMap
+import java.util.LinkedList
+import java.util.List
 import java.util.Map
+import java.util.TimeZone
+import org.eclipse.core.runtime.IPath
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.resource.ResourceSet
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
+import org.eclipse.emf.ecore.xmi.XMIResource
+import uk.ac.kcl.mdeoptimise.Optimisation
+import uk.ac.kcl.optimisation.moea.MoeaOptimisationSolution
 
 class MDEOResultsOutput {
 	
@@ -44,7 +43,7 @@ class MDEOResultsOutput {
 		batches.add(batch);
 	}
 	
-	def String outputBatchSummary(MDEOBatch batch, IPath outcomePath) {
+	def String outputBatchSummary(MDEOBatch batch, IPath outcomePath, IPath metaModelOutputPath) {
 		var batchOutputPath = outcomePath.append(String.format("batch-%s/", batch.id))
 		var batchInfoPath = batchOutputPath.append("outcome.txt")
 		
@@ -71,7 +70,7 @@ class MDEOResultsOutput {
 			val solution = batch.solutions.get(i);
 			val modelPath = batchOutputPath + String.format("%08X", solution.model.hashCode) + ".xmi"
 			
-			solution.model.writeModel(modelPath)
+			solution.model.writeModel(modelPath, metaModelOutputPath.toPortableString)
 			storeSolutionData(batchWriter, modelPath, solution)
 		}
 		
@@ -132,25 +131,42 @@ class MDEOResultsOutput {
 		}
 	}
 	
+	def IPath copyMetaModel(IPath outcomePath){
+		val metaModelInputPath = projectRoot.append(moptConfiguration.basepath.location).append(moptConfiguration.metamodel.location)
+		val metaModelOutputPath = outcomePath.append(metaModelInputPath.lastSegment)
+		
+		if (!metaModelInputPath.empty) {
+			val outputFile = metaModelOutputPath.toFile
+			Files.createParentDirs(outputFile)
+			Files.copy(metaModelInputPath.toFile, outputFile)
+		}
+		return metaModelOutputPath
+	}
+	
 	def void saveOutcome(){
 		
 		val experimentDate = new SimpleDateFormat("yyMMdd-HHmmss").format(experimentStartTime);
 		val outcomePath = projectRoot.append(String.format("mdeo-results/experiment-%s/", experimentDate));
+				
+		val metaModelOutputPath = copyMetaModel(outcomePath)
 		
 		val batchesOutput = new StringBuilder();
 		
-		batches.forEach[ batch | batchesOutput.append(outputBatchSummary(batch, outcomePath))]
+		batches.forEach[ batch | batchesOutput.append(outputBatchSummary(batch, outcomePath, metaModelOutputPath))]
 		
 		outputExperimentSummary(batches, outcomePath, moptFile, batchesOutput)
 	}
 	
-	def writeModel(EObject model, String path) {
-		val resource = resourceSet.createResource(URI.createFileURI(path))
+	def writeModel(EObject model, String path, String metaModelPath) {
+		val resource = resourceSet.createResource(URI.createFileURI(new File(path).absolutePath))
 		if (resource.loaded) {
 			resource.contents.clear
 		}
 		resource.contents.add(model)
 		
+		// Change URI of model package to reference the meta model copied to output location
+		model.eClass.EPackage.eResource.URI = URI.createFileURI(metaModelPath)
+				
 		// Keep schema location in output models
 		val Map<Object,Object> options = new HashMap<Object,Object>();
 		options.put(XMIResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);

--- a/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise.ui/src/uk/ac/kcl/ui/output/MDEOResultsOutput.xtend
@@ -18,6 +18,8 @@ import java.util.TimeZone
 import java.util.HashMap
 import com.google.common.io.Files
 import java.nio.charset.Charset
+import org.eclipse.emf.ecore.xmi.XMIResource
+import java.util.Map
 
 class MDEOResultsOutput {
 	
@@ -148,7 +150,12 @@ class MDEOResultsOutput {
 			resource.contents.clear
 		}
 		resource.contents.add(model)
-		resource.save(Collections.EMPTY_MAP)
+		
+		// Keep schema location in output models
+		val Map<Object,Object> options = new HashMap<Object,Object>();
+		options.put(XMIResource.OPTION_SCHEMA_LOCATION, Boolean.TRUE);
+		
+		resource.save(options)
 	}
 
 	private def storeSolutionData(PrintWriter infoWriter, String modelPath, MoeaOptimisationSolution solution){

--- a/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
@@ -1,32 +1,29 @@
 package uk.ac.kcl.optimisation
 
 import java.util.ArrayList
+import java.util.Arrays
 import java.util.Iterator
 import java.util.List
 import java.util.Random
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EPackage
 import org.eclipse.emf.ecore.util.EcoreUtil
+import org.eclipse.emf.henshin.interpreter.EGraph
 import org.eclipse.emf.henshin.interpreter.Engine
 import org.eclipse.emf.henshin.interpreter.impl.ChangeImpl
 import org.eclipse.emf.henshin.interpreter.impl.EGraphImpl
 import org.eclipse.emf.henshin.interpreter.impl.EngineImpl
 import org.eclipse.emf.henshin.interpreter.impl.RuleApplicationImpl
+import org.eclipse.emf.henshin.interpreter.impl.UnitApplicationImpl
+import org.eclipse.emf.henshin.model.HenshinPackage
+import org.eclipse.emf.henshin.model.ParameterKind
 import org.eclipse.emf.henshin.model.Unit
 import uk.ac.kcl.interpreter.IModelProvider
+import uk.ac.kcl.interpreter.evolvers.parameters.EvolverParametersFactory
+import uk.ac.kcl.interpreter.evolvers.parameters.IEvolverParametersFactory
 import uk.ac.kcl.mdeoptimise.Optimisation
 
 import static org.eclipse.emf.henshin.interpreter.impl.ChangeImpl.*
-import org.eclipse.emf.henshin.model.Rule
-import org.eclipse.emf.henshin.interpreter.impl.UnitApplicationImpl
-import uk.ac.kcl.interpreter.evolvers.parameters.IEvolverParametersFactory
-import org.eclipse.emf.henshin.model.HenshinPackage
-import org.eclipse.emf.henshin.interpreter.EGraph
-import java.util.Arrays
-import uk.ac.kcl.interpreter.evolvers.parameters.EvolverParametersFactory
-import org.eclipse.emf.henshin.model.ParameterKind
-import com.google.common.collect.Iterables
-import org.eclipse.emf.henshin.interpreter.impl.LoggingApplicationMonitor
 
 class SolutionGenerator {
 
@@ -145,7 +142,7 @@ class SolutionGenerator {
 		ruleRunner.EGraph = graph
 		ruleRunner.unit = operator
 		
-		if(operator.parameters != null){
+		if(operator.parameters !== null){
 			var inParameters = operator.parameters.filter[parameter | parameter.kind.equals(ParameterKind.IN) 
 				|| parameter.kind.equals(ParameterKind.INOUT)
 			]
@@ -161,7 +158,7 @@ class SolutionGenerator {
 		}
 		
 		//Run the selected Henshin Rule
-		return ruleRunner.execute(new LoggingApplicationMonitor)	
+		return ruleRunner.execute(null)	
 		
 	}
 	
@@ -182,7 +179,7 @@ class SolutionGenerator {
 		}
 		
 		//Run the selected Henshin Unit
-		return unitRunner.execute(new LoggingApplicationMonitor)
+		return unitRunner.execute(null)
 	}
 	
 

--- a/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
@@ -104,15 +104,15 @@ class SolutionGenerator {
 			if(operator.eClass().getClassifierID() == HenshinPackage.RULE){
 				//Run the selected Henshin Rule
 				
-				if(runRuleOperator(operator, firstRunGraph, parents)
-					&& runRuleOperator(operator, secondRunGraph, parents.reverseView)
+				if(runRuleOperator(operator, firstRunGraph, firstRunParents)
+					&& runRuleOperator(operator, secondRunGraph, secondRunParents)
 				){
 					//println("Could run mutation" + matchToUse.name)
 					return #[firstRunGraph.roots.get(1), secondRunGraph.roots.get(1)]
 				}
 			} else {
-				if(runUnitOperator(operator, firstRunGraph, parents)
-					&& runUnitOperator(operator, secondRunGraph, parents.reverseView)
+				if(runUnitOperator(operator, firstRunGraph, firstRunParents)
+					&& runUnitOperator(operator, secondRunGraph, secondRunParents)
 				){
 					//println("Could run mutation" + matchToUse.name)
 					return #[firstRunGraph.roots.get(1), secondRunGraph.roots.get(1)]

--- a/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/SolutionGenerator.xtend
@@ -144,8 +144,7 @@ class SolutionGenerator {
 		
 		if(operator.parameters !== null){
 			var inParameters = operator.parameters.filter[parameter | parameter.kind.equals(ParameterKind.IN) 
-				|| parameter.kind.equals(ParameterKind.INOUT)
-			]
+				|| parameter.kind.equals(ParameterKind.INOUT)]
 			
 			if(!inParameters.empty){
 				inParameters.forEach[  
@@ -167,8 +166,9 @@ class SolutionGenerator {
 		unitRunner.EGraph = graph
 		unitRunner.unit = operator
 		
-		var inParameters = operator.parameters.filter[parameter | parameter.kind.equals(ParameterKind.IN)]
-		
+		var inParameters = operator.parameters.filter[parameter | parameter.kind.equals(ParameterKind.IN)
+			|| parameter.kind.equals(ParameterKind.INOUT)]
+			
 		if(!inParameters.empty){
 			inParameters.forEach[ 
 				parameter | unitRunner.setParameterValue(

--- a/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/moea/MoeaProbabilisticVariation.xtend
+++ b/src/plugins/uk.ac.kcl.mdeoptimise/src/uk/ac/kcl/optimisation/moea/MoeaProbabilisticVariation.xtend
@@ -45,20 +45,18 @@ class MoeaProbabilisticVariation implements Variation {
 			println("Not running crossover this run")
 		}
 		
-		var solutions = new LinkedList<Solution>();
-		
 		for(var i = 0; i < result.length; i++){
 			
 			var mutationProbability = random.nextDouble
 			if(mutationProbability <= mutationRate){
 				println("Running mutation with probability: " + mutationProbability)
-				solutions.addAll(mutationOperator.evolve(#[result.get(i)]))
+				result.set(i, mutationOperator.evolve(#[result.get(i)]).get(0))
 			} else {
 				println("Not running mutation this run")
 			}
 		}
 		
-		return solutions;	
+		return result;
 
 	}
 	


### PR DESCRIPTION
A first try to run outplace crossover in MDEO by copying the parents twice and then applying the same Henshin rule separately on each copied pair. The motivation was that performing crossover inplace introduces adhoc changes to the parentes and therefore destroys the structure we would like to copy while we are still in the process of copying it.

Currently the implementation of crossover has moved to GraphTransformationCrossover.