### PR TITLE
catching exceptions eventually thrown when getting hardware info; not…

### DIFF
--- a/libraries/core/src/main/java/uk/ac/kcl/inf/mdeoptimiser/libraries/core/optimisation/output/descriptors/SystemInformationDescriptor.java
+++ b/libraries/core/src/main/java/uk/ac/kcl/inf/mdeoptimiser/libraries/core/optimisation/output/descriptors/SystemInformationDescriptor.java
@@ -70,16 +70,20 @@ public class SystemInformationDescriptor implements ResultsDescriptor {
    * @return string containing hardware information
    */
   public String getHardwareInfo() {
-    var hardwareAbstractionLayer = systemInfo.getHardware();
-    var centralProcessor = hardwareAbstractionLayer.getProcessor();
-    return String.join(
-        "\n",
-        String.format("Processor: %s", centralProcessor.getName()),
-        String.format(
-            "Processor Cores: %s physical %s logical",
-            centralProcessor.getPhysicalProcessorCount(),
-            centralProcessor.getLogicalProcessorCount()),
-        String.format(
-            "Memory: %s GB", hardwareAbstractionLayer.getMemory().getTotal() / 1073741824d));
+	try {
+		var hardwareAbstractionLayer = systemInfo.getHardware();
+		var centralProcessor = hardwareAbstractionLayer.getProcessor();
+		return String.join(
+			"\n",
+			String.format("Processor: %s", centralProcessor.getName()),
+			String.format(
+				"Processor Cores: %s physical %s logical",
+				centralProcessor.getPhysicalProcessorCount(),
+				centralProcessor.getLogicalProcessorCount()),
+			String.format(
+				"Memory: %s GB", hardwareAbstractionLayer.getMemory().getTotal() / 1073741824d));
+	} catch (Exception e) {
+		return "Hardware info not available";
+	}
   }
 }


### PR DESCRIPTION
A quick and dirty fix for the system crashing with an exception when hardware info cannot properly be detected. Exceptions are caught now and a substitute string "Hardware info not available" is returned.