### PR TITLE
Fix/dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '21'
         distribution: 'adopt'
     - name: Build with Ant
       uses: GabrielBB/xvfb-action@v1
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'adopt'
       - name: Build with Ant
         uses: GabrielBB/xvfb-action@v1

--- a/Readme.md
+++ b/Readme.md
@@ -14,8 +14,8 @@ This is the main repository for  [MDEOptimiser](http://mde-optimiser.github.io).
 
 Requirements:
 
-	Eclipse Version 2019-03
-	Java 11
+	Eclipse Version 2025-03
+	Java 21
 
 Install the version of MDEOptimiser you would like to
 use from one of the Eclipse Update sites below.

--- a/build/maven/build.xml
+++ b/build/maven/build.xml
@@ -1,17 +1,28 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project name="mopt.xtext" default="default">
+<project name="mopt.xtext" 
+         default="default"
+         xmlns:if="ant:if"
+         xmlns:unless="ant:unless">
     <import file="../ant/build-common.xml"/>
 
 	<condition property="isWindows">
 		<os family="windows" />
 	</condition>
 
-    <!-- Set skipTests based on environment variable or property -->
+    <!-- Set doSkipTests based on environment variable or property -->
     <!-- So, running eg: ant -DskipTests=true OR export SKIP_TESTS=true && ant (to set an env var - can be used in github to skip for certain builds/branches) -->
-    <condition property="doSkipTests" value='"-Dmaven.test.skip"' else="">
+    <condition property="doSkipTests" value="true">
         <or>
             <isset property="env.SKIP_TESTS"/>
             <isset property="skipTests"/>
+        </or>
+    </condition>
+
+    <!-- Enable skipping of clean to speed up dev builds -->
+    <condition property="doSkipClean" value="true">
+        <or>
+            <isset property="env.SKIP_CLEAN"/>
+            <isset property="skipClean"/>
         </or>
     </condition>
 
@@ -21,19 +32,19 @@
         <exec dir="." executable="cmd" failifexecutionfails="true" failonerror="true">
 			<arg value="/c"/>
 			<arg value="mvn"/>
-            <arg value="clean" />
+            <arg value="clean" if:blank="${doSkipClean}" />
             <arg value="deploy" />
             <arg value="--quiet" />
-            <arg value="${doSkipTests}" />
+            <arg value='"-Dmaven.test.skip"' unless:blank="${doSkipTests}" />
         </exec>
     </target>
 	
 	<target name="maven.build" unless="isWindows">
         <exec dir="." executable="mvn" failifexecutionfails="true" failonerror="true">
-            <arg value="clean" />
+            <arg value="clean" if:blank="${doSkipClean}" />
             <arg value="deploy" /> 
             <arg value="--quiet" />
-            <arg value="${doSkipTests}" />
+            <arg value="-Dmaven.test.skip" unless:blank="${doSkipTests}" />
         </exec>
     </target>
 

--- a/build/maven/build.xml
+++ b/build/maven/build.xml
@@ -6,6 +6,15 @@
 		<os family="windows" />
 	</condition>
 
+    <!-- Set skipTests based on environment variable or property -->
+    <!-- So, running eg: ant -DskipTests=true OR export SKIP_TESTS=true && ant (to set an env var - can be used in github to skip for certain builds/branches) -->
+    <condition property="doSkipTests" value='"-Dmaven.test.skip"' else="">
+        <or>
+            <isset property="env.SKIP_TESTS"/>
+            <isset property="skipTests"/>
+        </or>
+    </condition>
+
     <target name="dist" depends="render.maven.properties.template, maven.build, maven.build.windows"/>
 
     <target name="maven.build.windows" if="isWindows">
@@ -15,15 +24,16 @@
             <arg value="clean" />
             <arg value="deploy" />
             <arg value="--quiet" />
+            <arg value="${doSkipTests}" />
         </exec>
     </target>
 	
 	<target name="maven.build" unless="isWindows">
         <exec dir="." executable="mvn" failifexecutionfails="true" failonerror="true">
             <arg value="clean" />
-            <!-- TODO: Consider putting the next into a separate target and use something like compile instead to avoid packaging everything on every commit to a PR. -->
             <arg value="deploy" /> 
             <arg value="--quiet" />
+            <arg value="${doSkipTests}" />
         </exec>
     </target>
 

--- a/build/maven/build.xml
+++ b/build/maven/build.xml
@@ -26,25 +26,33 @@
         </or>
     </condition>
 
-    <target name="dist" depends="render.maven.properties.template, maven.build, maven.build.windows"/>
+    <target name="dist" depends="render.skipTests, render.skipClean, render.maven.properties.template, maven.build, maven.build.windows"/>
+
+    <target name="render.skipTests" if="doSkipTests">
+        <echo message="Skipping tests" />
+    </target>
+
+    <target name="render.skipClean" if="doSkipClean">
+        <echo message="Skipping cleaning" />
+    </target>
 
     <target name="maven.build.windows" if="isWindows">
         <exec dir="." executable="cmd" failifexecutionfails="true" failonerror="true">
 			<arg value="/c"/>
 			<arg value="mvn"/>
-            <arg value="clean" if:blank="${doSkipClean}" />
+            <arg value="clean" unless:true="${doSkipClean}" />
             <arg value="deploy" />
             <arg value="--quiet" />
-            <arg value='"-Dmaven.test.skip"' unless:blank="${doSkipTests}" />
+            <arg value='"-Dmaven.test.skip"' if:true="${doSkipTests}" />
         </exec>
     </target>
 	
 	<target name="maven.build" unless="isWindows">
         <exec dir="." executable="mvn" failifexecutionfails="true" failonerror="true">
-            <arg value="clean" if:blank="${doSkipClean}" />
+            <arg value="clean" unless:true="${doSkipClean}" />
             <arg value="deploy" /> 
             <arg value="--quiet" />
-            <arg value="-Dmaven.test.skip" unless:blank="${doSkipTests}" />
+            <arg value="-Dmaven.test.skip" if:true="${doSkipTests}" />
         </exec>
     </target>
 

--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -48,13 +48,20 @@
       </repository>
   </distributionManagement>
   <repositories>
-      <repository>
-          <id>p2.eclipse.repository</id>
-          <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2019-03/final/</url>
-      </repository>
-      <repository>
-		<id>m2.moeaframework</id>
-		<url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/moeaframework/</url>
+    <repository>
+        <id>p2.henshin.repository</id>
+        <url>https://download.eclipse.org/modeling/emft/henshin/updates/release</url>          
+    </repository>
+    <repository>
+        <id>p2.eclipse.repository</id>
+        <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2025-03/final/</url>
+        <releases>
+          <updatePolicy>always</updatePolicy>
+        </releases>
+    </repository>
+    <repository>
+      <id>m2.moeaframework</id>
+      <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/moeaframework/</url>
 	  </repository>
   </repositories>
   <!-- Load JUnit 5 Bom -->

--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -33,8 +33,8 @@
     <repositories.output.p2.eclipse>${repositories.output.root}/p2/p2.eclipse.repository</repositories.output.p2.eclipse>
     <xtextVersion>2.38.0</xtextVersion>
     <xtend.version>2.38.0</xtend.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter.version>5.4.1</junit-jupiter.version>
   </properties>

--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -35,6 +35,7 @@
     <xtend.version>2.38.0</xtend.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter.version>5.4.1</junit-jupiter.version>
   </properties>

--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -31,8 +31,8 @@
     <repositories.output.m2.mdeoptimiser>${repositories.output.root}/m2/m2.mdeoptimiser.repository</repositories.output.m2.mdeoptimiser>
     <repositories.output.p2.mdeoptimiser>${repositories.output.root}/p2/p2.mdeoptimiser.repository</repositories.output.p2.mdeoptimiser>
     <repositories.output.p2.eclipse>${repositories.output.root}/p2/p2.eclipse.repository</repositories.output.p2.eclipse>
-    <xtextVersion>2.17.0</xtextVersion>
-    <xtend.version>2.17.0</xtend.version>
+    <xtextVersion>2.38.0</xtextVersion>
+    <xtend.version>2.38.0</xtend.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/build/maven/template/pom.xml.template
+++ b/build/maven/template/pom.xml.template
@@ -33,9 +33,9 @@
     <repositories.output.p2.eclipse>${repositories.output.root}/p2/p2.eclipse.repository</repositories.output.p2.eclipse>
     <xtextVersion>2.38.0</xtextVersion>
     <xtend.version>2.38.0</xtend.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter.version>5.4.1</junit-jupiter.version>
   </properties>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="dependencies" default="depend.all">
-    
-	<condition property="isWindows">
-		<os family="windows" />
-	</condition>
-	
-	<target name="windows.directory.format" if="isWindows">
-		<dirname property="dependencies.basedir.windows" file="${ant.file.dependencies}"/>
-        <path id="dependencies.basedir.path">
-			<pathelement path="${dependencies.basedir.windows}" />
-		</path>
-		<pathconvert targetos="unix" property="dependencies.basedir" refid="dependencies.basedir.path"/>
-    </target>
-	
-	<target name="unix.directory.format" unless="isWindows">
-	     <dirname property="dependencies.basedir" file="${ant.file.dependencies}"/>
-    </target>
+        <condition property="isWindows">
+                <os family="windows" />
+        </condition>
 
-    <!-- ================================================================== -->
-    <target name="depend.all" depends="depend.maven, depend.eclipse">
-    </target>
+        <target name="windows.directory.format" if="isWindows">
+                <dirname property="dependencies.basedir.windows" file="${ant.file.dependencies}"/>
+                <path id="dependencies.basedir.path">
+                        <pathelement path="${dependencies.basedir.windows}" />
+                </path>
+                <pathconvert targetos="unix" property="dependencies.basedir" refid="dependencies.basedir.path"/>
+        </target>
 
-    <!-- Maven Builds -->
-    <!-- ================================================================== -->
-    <target name="depend.maven" depends="windows.directory.format, unix.directory.format">
-            <ant dir="${dependencies.basedir}/build/maven" inheritAll="true"/>
-    </target>
+        <target name="unix.directory.format" unless="isWindows">
+                <dirname property="dependencies.basedir" file="${ant.file.dependencies}"/>
+        </target>
 
-    <!-- Eclipse Builds -->
-    <target name="depend.eclipse" depends="depend.maven">
-            <ant dir="${dependencies.basedir}/interfaces/eclipse" inheritAll="true"/>
-    </target>
+        <!-- ================================================================== -->
+        <target name="depend.all" depends="depend.maven, depend.eclipse">
+        </target>
 
+        <!-- Maven Builds -->
+        <!-- ================================================================== -->
+        <target name="depend.maven" depends="windows.directory.format, unix.directory.format">
+                <ant dir="${dependencies.basedir}/build/maven" inheritAll="true"/>
+        </target>
+
+        <!-- Eclipse Builds -->
+        <target name="depend.eclipse" depends="depend.maven">
+                <ant dir="${dependencies.basedir}/interfaces/eclipse" inheritAll="true"/>
+        </target>
 </project>

--- a/examples/problems/argumentation/pom.xml
+++ b/examples/problems/argumentation/pom.xml
@@ -49,8 +49,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>21</source>
+					<target>21</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/examples/problems/cra/META-INF/MANIFEST.MF
+++ b/examples/problems/cra/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: 
  models.cra.fitness.architectureCRA,
  models.cra.fitness.architectureCRA.impl,

--- a/examples/problems/pom.xml
+++ b/examples/problems/pom.xml
@@ -35,8 +35,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/problems/tsp/META-INF/MANIFEST.MF
+++ b/examples/problems/tsp/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: J2SE-21
 Export-Package: models.tsp.fitness.TSP,
  models.tsp.fitness.TSP.impl,
  models.tsp.fitness.TSP.util

--- a/examples/problems/tsp/pom.xml
+++ b/examples/problems/tsp/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.eclipse.xtext</groupId>
             <artifactId>org.eclipse.xtext.testing</artifactId>
-            <version>2.18.0</version>
+            <version>${xtextVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/problems/ttc-18/pom.xml
+++ b/examples/problems/ttc-18/pom.xml
@@ -8,7 +8,7 @@
 
 	<properties>
 		<tycho-version>1.0.0</tycho-version>
-		<xtextVersion>2.12.0</xtextVersion>
+		<xtextVersion>2.38.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/problems/ttc-18/resource-allocation/pom.xml
+++ b/examples/problems/ttc-18/resource-allocation/pom.xml
@@ -35,8 +35,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>21</source>
+					<target>21</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ide/META-INF/MANIFEST.MF
+++ b/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ide/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: uk.ac.kcl.mdeo.ttc18.hsqos,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.antlr.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.xtext.example.mydsl.ide.contentassist.antlr.internal,
  org.xtext.example.mydsl.ide.contentassist.antlr
 

--- a/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.tests/META-INF/MANIFEST.MF
+++ b/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.tests/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: uk.ac.kcl.mdeo.ttc18.hsqos,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.xbase.lib,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.xtext.example.mydsl.tests;x-internal=true
 Import-Package: org.hamcrest.core,
  org.junit;version="4.5.0",

--- a/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ui.tests/META-INF/MANIFEST.MF
+++ b/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ui.tests/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: uk.ac.kcl.mdeo.ttc18.hsqos.ui,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Import-Package: org.hamcrest.core,
  org.junit;version="4.5.0",
  org.junit.runners.model;version="4.5.0",

--- a/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ui/META-INF/MANIFEST.MF
+++ b/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: uk.ac.kcl.mdeo.ttc18.hsqos,
  org.eclipse.xtext.xbase.ui,
  org.eclipse.jdt.debug.ui
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.xtext.example.mydsl.ui.contentassist,
  org.xtext.example.mydsl.ui.quickfix,
  uk.ac.kcl.mdeo.ttc18.hsqos.ui.internal

--- a/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos/META-INF/MANIFEST.MF
+++ b/examples/problems/ttc-18/uk.ac.kcl.mdeo.ttc18.hsqos/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.common,
  org.eclipse.xtext.common.types,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: org.xtext.example.mydsl.myDsl.util,
  org.xtext.example.mydsl.parser.antlr.internal,
  org.xtext.example.mydsl.scoping,

--- a/interfaces/cli/pom.xml
+++ b/interfaces/cli/pom.xml
@@ -67,17 +67,17 @@
 		<dependency>
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
-			<version>3.9.2</version>
+			<version>4.7.6</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>3.0</version>
+			<version>[6.0.0,)</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
-			<version>1.2</version>
+			<version>1.9.0</version>
 		</dependency>
 		<dependency>
 			<groupId>
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.core.runtime</artifactId>
-			<version>[3.13.0,4.0.0)</version>
+			<version>[3.33.0,4.0.0)</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/interfaces/cli/pom.xml
+++ b/interfaces/cli/pom.xml
@@ -20,8 +20,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.source}</target>
 				</configuration>
 			</plugin>
 			

--- a/interfaces/eclipse/build.xml
+++ b/interfaces/eclipse/build.xml
@@ -40,7 +40,7 @@
 
     <!-- Render target file from a template to point to the local maven repository -->
 
-    <target name="render.target.template">
+    <target name="render.target.template" depends="windows.directory.format, unix.directory.format">
 
         <!-- Copy task that replaces values and copies the files -->
         <copy todir="src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/" verbose="true" overwrite="true" failonerror="true">

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -262,7 +262,10 @@
 					<configuration>
 						<compilerArgument>-err:-forbidden</compilerArgument>
 						<useProjectSettings>false</useProjectSettings>
-						<compilerVersion>1.17</compilerVersion>
+						<!-- Eclipse 2025-03 requires JavaSE-21. We're compiling all our code to work against 1.17, 
+						     but need to compile the Eclipse stuff against 21. -->
+						<compilerVersion>1.21</compilerVersion>
+						<fork>true</fork>
 					</configuration>
 				</plugin>
 				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -10,8 +10,8 @@
 	<properties>
 		<xtextVersion>2.38.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<!-- Tycho settings -->
 		<tycho-version>1.4.0</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -93,7 +93,7 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<!-- <executionEnvironment>JavaSE-17</executionEnvironment> -->
 					<target>
 						<artifact>
 							<groupId>uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse</groupId>

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -262,10 +262,11 @@
 					<configuration>
 						<compilerArgument>-err:-forbidden</compilerArgument>
 						<useProjectSettings>false</useProjectSettings>
+						<!-- It seems the below isn't actually needed, now that the BREE has been updated in the manifest files for all plugins. -->
 						<!-- Eclipse 2025-03 requires JavaSE-21. We're compiling all our code to work against 1.17, 
 						     but need to compile the Eclipse stuff against 21. -->
-						<compilerVersion>1.21</compilerVersion>
-						<fork>true</fork>
+						<!-- <compilerVersion>1.21</compilerVersion>
+						<fork>true</fork> -->
 					</configuration>
 				</plugin>
 				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -12,6 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
+	    <maven.compiler.release>17</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>1.4.0</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -14,7 +14,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 	    <maven.compiler.release>17</maven.compiler.release>
 		<!-- Tycho settings -->
-		<tycho-version>1.4.0</tycho-version>
+		<tycho-version>4.0.11</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->
 		<platformSystemProperties></platformSystemProperties>
 		<moduleProperties></moduleProperties>
@@ -61,15 +61,15 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<executions>
 					<execution>
-						<id>source-feature</id>
+						<id>feature-source</id>
 						<phase>package</phase>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>feature-source</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -93,6 +93,7 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<target>
 						<artifact>
 							<groupId>uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse</groupId>
@@ -261,6 +262,7 @@
 					<configuration>
 						<compilerArgument>-err:-forbidden</compilerArgument>
 						<useProjectSettings>false</useProjectSettings>
+						<compilerVersion>1.17</compilerVersion>
 					</configuration>
 				</plugin>
 				<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<xtextVersion>2.17.0</xtextVersion>
+		<xtextVersion>2.38.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>

--- a/interfaces/eclipse/src/pom.xml
+++ b/interfaces/eclipse/src/pom.xml
@@ -10,9 +10,9 @@
 	<properties>
 		<xtextVersion>2.38.0</xtextVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-	    <maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+	    <maven.compiler.release>21</maven.compiler.release>
 		<!-- Tycho settings -->
 		<tycho-version>4.0.11</tycho-version>
 		<!-- Define overridable properties for tycho-surefire-plugin -->

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -6,15 +6,15 @@
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/2019-03"/>
+<repository location="http://download.eclipse.org/releases/2025-03"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.10.0/"/>
+<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.17.0/"/>
+<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 	<unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
@@ -29,7 +29,7 @@
 	<unit id="org.opentest4j" version="1.1.1.v20190212-2109"/>
 	<unit id="org.objectweb.asm" version="7.0.0.v20181030-2244"/>
 	<unit id="org.objectweb.asm.tree" version="7.0.0.v20181030-2244"/>
-	<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-03"/>
+	<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2025-03"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ocl.examples.classic.feature.group" version="5.2.1.v20160808-1416"/>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -24,12 +24,12 @@
 			<unit id="com.google.gson" version="0.0.0"/>
 			<unit id="org.antlr.runtime" version="0.0.0"/>
 			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.junit.jupiter.api" version="0.0.0"/>
-			<unit id="org.junit.jupiter.engine" version="0.0.0"/>
-			<unit id="org.junit.platform.commons" version="0.0.0"/>
-			<unit id="org.junit.platform.engine" version="0.0.0"/>
-			<unit id="org.junit.platform.launcher" version="0.0.0"/>
-			<unit id="org.junit.platform.runner" version="0.0.0"/>
+			<unit id="junit-jupiter-api" version="0.0.0"/>
+			<unit id="junit-jupiter-engine" version="0.0.0"/>
+			<unit id="junit-platform-commons" version="0.0.0"/>
+			<unit id="junit-platform-engine" version="0.0.0"/>
+			<unit id="junit-platform-launcher" version="0.0.0"/>
+			<unit id="junit-platform-runner" version="0.0.0"/>
 			<unit id="org.opentest4j" version="0.0.0"/>
 			<unit id="org.objectweb.asm" version="0.0.0"/>
 			<unit id="org.objectweb.asm.tree" version="0.0.0"/>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -20,17 +20,17 @@
 			<unit id="org.objectweb.asm" version="0.0.0"/>
 			<unit id="org.objectweb.asm.tree" version="0.0.0"/>
 			<!-- <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/> -->
-			<repository location="http://download.eclipse.org/releases/2025-03"/>
+			<repository location="https://download.eclipse.org/releases/2025-03"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-			<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
+			<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
+			<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -44,7 +44,7 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.henshin.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.henshin.sdk.source.feature.group" version="0.0.0"/>
-			<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/release"/>
+			<repository location="https://download.eclipse.org/modeling/emft/henshin/updates/release"/>
 		</location>
 
 		<!-- TODO: Quite old stuff, but currently required by some of the Henshin stuff. Could, alternatively, only load the Henshin bundles we actually depend on.

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -47,6 +47,13 @@
 			<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/release"/>
 		</location>
 
+		<!-- TODO: Quite old stuff, but currently required by some of the Henshin stuff. Could, alternatively, only load the Henshin bundles we actually depend on.
+		     In particular, henshin.text depends on javax.annotation, but we don't strictly need it. -->
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="javax.annotation" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/oomph/simrel-orbit/release/4.28.0"/>
+		</location>
+
 		<!-- Also need to provide access to some Papyrus packages, which Henshin depends on... -->		
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.papyrus.infra.gmfdiag.tooling.runtime" version="0.0.0"/>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -37,11 +37,11 @@
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.ocl.examples.classic.feature.group" version="5.2.1.v20160808-1416"/>
-			<unit id="org.eclipse.ocl.examples.feature.group" version="6.1.1.v20160808-1615"/>
-			<unit id="org.eclipse.ocl.examples.unified.feature.group" version="4.1.1.v20160808-1615"/>
-			<unit id="org.eclipse.ocl.master.feature.group" version="6.1.1.v20160808-1615"/>
-			<repository location="http://download.eclipse.org/modeling/mdt/ocl/updates/releases/6.1.1/"/>
+			<unit id="org.eclipse.ocl.examples.classic.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.ocl.examples.unified.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.ocl.master.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/modeling/mdt/ocl/builds/release/6.22.0"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -7,6 +7,19 @@
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<unit id="com.google.gson" version="0.0.0"/>
+			<unit id="org.antlr.runtime" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+			<unit id="junit-jupiter-api" version="0.0.0"/>
+			<unit id="junit-jupiter-engine" version="0.0.0"/>
+			<unit id="junit-platform-commons" version="0.0.0"/>
+			<unit id="junit-platform-engine" version="0.0.0"/>
+			<unit id="junit-platform-launcher" version="0.0.0"/>
+			<unit id="junit-platform-runner" version="0.0.0"/>
+			<unit id="org.opentest4j" version="0.0.0"/>
+			<unit id="org.objectweb.asm" version="0.0.0"/>
+			<unit id="org.objectweb.asm.tree" version="0.0.0"/>
+			<!-- <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/> -->
 			<repository location="http://download.eclipse.org/releases/2025-03"/>
 		</location>
 
@@ -20,22 +33,6 @@
 			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
 		</location>
 
-		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="org.antlr.runtime" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="junit-jupiter-api" version="0.0.0"/>
-			<unit id="junit-jupiter-engine" version="0.0.0"/>
-			<unit id="junit-platform-commons" version="0.0.0"/>
-			<unit id="junit-platform-engine" version="0.0.0"/>
-			<unit id="junit-platform-launcher" version="0.0.0"/>
-			<unit id="junit-platform-runner" version="0.0.0"/>
-			<unit id="org.opentest4j" version="0.0.0"/>
-			<unit id="org.objectweb.asm" version="0.0.0"/>
-			<unit id="org.objectweb.asm.tree" version="0.0.0"/>
-			<repository location="http://download.eclipse.org/releases/2025-03"/>
-		</location>
-
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.ocl.examples.classic.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
@@ -47,7 +44,16 @@
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.emf.henshin.sdk.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.emf.henshin.sdk.source.feature.group" version="0.0.0"/>
-			<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/nightly"/>
+			<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/release"/>
+		</location>
+
+		<!-- Also need to provide access to some Papyrus packages, which Henshin depends on... -->		
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.papyrus.infra.gmfdiag.tooling.runtime" version="0.0.0"/>
+			<!-- It's tempting to try and install the whole feature, but for some reason that doesn't manage to resolve its Batik dependency even if it's included above...
+			<unit id="org.eclipse.papyrus.infra.gmfdiag.feature.feature.group" version="0.0.0"/> -->
+			<!-- TODO: Eventually, would want to update to 2025-03, but that doesn't currently exist... -->
+			<repository location="https://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2024-06"/>
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -21,18 +21,18 @@
 		</location>
 
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
-			<unit id="org.junit" version="4.12.0.v201504281640"/>
-			<unit id="org.junit.jupiter.api" version="5.4.0.v20190212-2109"/>
-			<unit id="org.junit.jupiter.engine" version="5.4.0.v20190212-2109"/>
-			<unit id="org.junit.platform.commons" version="1.4.0.v20190212-2109"/>
-			<unit id="org.junit.platform.engine" version="1.4.0.v20190212-2109"/>
-			<unit id="org.junit.platform.launcher" version="1.4.0.v20190212-2109"/>
-			<unit id="org.junit.platform.runner" version="1.4.0.v20190212-2109"/>
-			<unit id="org.opentest4j" version="1.1.1.v20190212-2109"/>
-			<unit id="org.objectweb.asm" version="7.0.0.v20181030-2244"/>
-			<unit id="org.objectweb.asm.tree" version="7.0.0.v20181030-2244"/>
+			<unit id="com.google.gson" version="0.0.0"/>
+			<unit id="org.antlr.runtime" version="0.0.0"/>
+			<unit id="org.junit" version="0.0.0"/>
+			<unit id="org.junit.jupiter.api" version="0.0.0"/>
+			<unit id="org.junit.jupiter.engine" version="0.0.0"/>
+			<unit id="org.junit.platform.commons" version="0.0.0"/>
+			<unit id="org.junit.platform.engine" version="0.0.0"/>
+			<unit id="org.junit.platform.launcher" version="0.0.0"/>
+			<unit id="org.junit.platform.runner" version="0.0.0"/>
+			<unit id="org.opentest4j" version="0.0.0"/>
+			<unit id="org.objectweb.asm" version="0.0.0"/>
+			<unit id="org.objectweb.asm.tree" version="0.0.0"/>
 			<repository location="http://download.eclipse.org/releases/2025-03"/>
 		</location>
 

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target/template/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target.target.template
@@ -1,76 +1,82 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?><target includeMode="feature" name="uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target" sequenceNumber="1">
-<locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/2025-03"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-	<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
-	<unit id="org.junit" version="4.12.0.v201504281640"/>
-	<unit id="org.junit.jupiter.api" version="5.4.0.v20190212-2109"/>
-	<unit id="org.junit.jupiter.engine" version="5.4.0.v20190212-2109"/>
-	<unit id="org.junit.platform.commons" version="1.4.0.v20190212-2109"/>
-	<unit id="org.junit.platform.engine" version="1.4.0.v20190212-2109"/>
-	<unit id="org.junit.platform.launcher" version="1.4.0.v20190212-2109"/>
-	<unit id="org.junit.platform.runner" version="1.4.0.v20190212-2109"/>
-	<unit id="org.opentest4j" version="1.1.1.v20190212-2109"/>
-	<unit id="org.objectweb.asm" version="7.0.0.v20181030-2244"/>
-	<unit id="org.objectweb.asm.tree" version="7.0.0.v20181030-2244"/>
-	<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2025-03"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.ocl.examples.classic.feature.group" version="5.2.1.v20160808-1416"/>
-<unit id="org.eclipse.ocl.examples.feature.group" version="6.1.1.v20160808-1615"/>
-<unit id="org.eclipse.ocl.examples.unified.feature.group" version="4.1.1.v20160808-1615"/>
-<unit id="org.eclipse.ocl.master.feature.group" version="6.1.1.v20160808-1615"/>
-<repository location="http://download.eclipse.org/modeling/mdt/ocl/updates/releases/6.1.1/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.emf.henshin.sdk.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.emf.henshin.sdk.source.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/nightly"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext" version="0.0.0"/>
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext.source" version="0.0.0"/>
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.interfaces.cli" version="0.0.0" />
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.interfaces.cli.source" version="0.0.0" />
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.core" version="0.0.0" />
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.core.source" version="0.0.0" />
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.rulegen" version="0.0.0" />
-	<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.rulegen.source" version="0.0.0" />
-	<unit id="org.moeaframework" version="0.0.0" />
-	<unit id="org.moeaframework.source" version="0.0.0" />
-	<unit id="com.github.mifmif.generex" version="0.0.0" />
-	<unit id="com.github.mifmif.generex.source" version="0.0.0" />
-	<unit id="dk.brics.automaton" version="1.11.0.8"/>
-	<unit id="org.apache.commons.cli" version="1.2.0"/>
-	<unit id="org.apache.commons.codec" version="1.8.0"/>
-	<unit id="org.apache.commons.lang3" version="3.1.0"/>
-	<unit id="org.apache.commons.math3" version="3.4.1"/>
-	<unit id="org.jfree.chart" version="1.0.15"/>
-	<unit id="org.jfree.jcommon" version="1.0.21"/>
-	<unit id="org.hamcrest.java-hamcrest" version="2.0.0.0"/>
-	<unit id="org.sidiff.serge" version="0.0.0" />
-	<unit id="com.github.oshi.oshi-core" version="0.0.0" />
-    <unit id="com.github.oshi.oshi-core.source" version="0.0.0" />
-    <unit id="org.apache.commons.lang3" version="3.8.1"/>
-	<unit id="org.apache.commons.math3" version="3.6.1"/>
-	<repository location="file:/${dependencies.basedir}/repositories/output/p2/p2.mdeoptimiser.repository"/>
-</location>
-</locations>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.8"?>
+<target includeMode="feature" name="uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.target" sequenceNumber="1">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/releases/2025-03"/>
+		</location>
 
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
+			<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
+			<unit id="org.junit" version="4.12.0.v201504281640"/>
+			<unit id="org.junit.jupiter.api" version="5.4.0.v20190212-2109"/>
+			<unit id="org.junit.jupiter.engine" version="5.4.0.v20190212-2109"/>
+			<unit id="org.junit.platform.commons" version="1.4.0.v20190212-2109"/>
+			<unit id="org.junit.platform.engine" version="1.4.0.v20190212-2109"/>
+			<unit id="org.junit.platform.launcher" version="1.4.0.v20190212-2109"/>
+			<unit id="org.junit.platform.runner" version="1.4.0.v20190212-2109"/>
+			<unit id="org.opentest4j" version="1.1.1.v20190212-2109"/>
+			<unit id="org.objectweb.asm" version="7.0.0.v20181030-2244"/>
+			<unit id="org.objectweb.asm.tree" version="7.0.0.v20181030-2244"/>
+			<repository location="http://download.eclipse.org/releases/2025-03"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.ocl.examples.classic.feature.group" version="5.2.1.v20160808-1416"/>
+			<unit id="org.eclipse.ocl.examples.feature.group" version="6.1.1.v20160808-1615"/>
+			<unit id="org.eclipse.ocl.examples.unified.feature.group" version="4.1.1.v20160808-1615"/>
+			<unit id="org.eclipse.ocl.master.feature.group" version="6.1.1.v20160808-1615"/>
+			<repository location="http://download.eclipse.org/modeling/mdt/ocl/updates/releases/6.1.1/"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.eclipse.emf.henshin.sdk.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.emf.henshin.sdk.source.feature.group" version="0.0.0"/>
+			<repository location="http://download.eclipse.org/modeling/emft/henshin/updates/nightly"/>
+		</location>
+
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext" version="0.0.0"/>
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext.source" version="0.0.0"/>
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.interfaces.cli" version="0.0.0" />
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.interfaces.cli.source" version="0.0.0" />
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.core" version="0.0.0" />
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.core.source" version="0.0.0" />
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.rulegen" version="0.0.0" />
+			<unit id="uk.ac.kcl.inf.mdeoptimiser.libraries.rulegen.source" version="0.0.0" />
+			<unit id="org.moeaframework" version="0.0.0" />
+			<unit id="org.moeaframework.source" version="0.0.0" />
+			<unit id="com.github.mifmif.generex" version="0.0.0" />
+			<unit id="com.github.mifmif.generex.source" version="0.0.0" />
+			<unit id="dk.brics.automaton" version="1.11.0.8"/>
+			<unit id="org.apache.commons.cli" version="1.2.0"/>
+			<unit id="org.apache.commons.codec" version="1.8.0"/>
+			<unit id="org.apache.commons.lang3" version="3.1.0"/>
+			<unit id="org.apache.commons.math3" version="3.4.1"/>
+			<unit id="org.jfree.chart" version="1.0.15"/>
+			<unit id="org.jfree.jcommon" version="1.0.21"/>
+			<unit id="org.hamcrest.java-hamcrest" version="2.0.0.0"/>
+			<unit id="org.sidiff.serge" version="0.0.0" />
+			<unit id="com.github.oshi.oshi-core" version="0.0.0" />
+			<unit id="com.github.oshi.oshi-core.source" version="0.0.0" />
+			<unit id="org.apache.commons.lang3" version="3.8.1"/>
+			<unit id="org.apache.commons.math3" version="3.6.1"/>
+			<repository location="file:/${dependencies.basedir}/repositories/output/p2/p2.mdeoptimiser.repository"/>
+		</location>
+	</locations>
 </target>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/.classpath
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/.classpath
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/">
 		<attributes>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.ui.tests;x-internal=true

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -7,11 +7,10 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui,
- org.junit.jupiter.api;bundle-version="[5.0.0,6.0.0)",
+ junit-jupiter-api;bundle-version="[5.0.0,6.0.0)",
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.junit4,
- org.eclipse.xtext.xbase.junit,
+ org.eclipse.xtext.ui.testing,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Require-Bundle: uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.ui.tests;x-internal=true

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/pom.xml
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/pom.xml
@@ -29,7 +29,7 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<!-- <executionEnvironment>JavaSE-17</executionEnvironment> -->
 					<dependency-resolution>
 						<extraRequirements>
 							<!-- to get the org.eclipse.osgi.compatibility.state plugin

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/pom.xml
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui.tests/pom.xml
@@ -29,6 +29,7 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<configuration>
+					<executionEnvironment>JavaSE-17</executionEnvironment>
 					<dependency-resolution>
 						<extraRequirements>
 							<!-- to get the org.eclipse.osgi.compatibility.state plugin

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/.classpath
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="src" path="src-gen/"/>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/.classpath
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="src" path="src-gen/"/>

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/META-INF/MANIFEST.MF
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Require-Bundle: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext,
  org.eclipse.xtend.lib.macro,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.ui.contentassist,
  uk.ac.kcl.inf.mdeoptimiser.languages.ui.quickfix,
  uk.ac.kcl.inf.mdeoptimiser.languages.ui.editor,

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/META-INF/MANIFEST.MF
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Require-Bundle: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext,
  org.eclipse.xtend.lib.macro,
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)"
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.ui.contentassist,
  uk.ac.kcl.inf.mdeoptimiser.languages.ui.quickfix,
  uk.ac.kcl.inf.mdeoptimiser.languages.ui.editor,

--- a/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/src-gen/uk/ac/kcl/inf/mdeoptimiser/languages/ide/AbstractMoptIdeModule.java
+++ b/interfaces/eclipse/src/uk.ac.kcl.inf.mdeoptimiser.interfaces.eclipse.ui/src-gen/uk/ac/kcl/inf/mdeoptimiser/languages/ide/AbstractMoptIdeModule.java
@@ -13,8 +13,8 @@ import org.eclipse.xtext.ide.editor.contentassist.antlr.AntlrProposalConflictHel
 import org.eclipse.xtext.ide.editor.contentassist.antlr.IContentAssistParser;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.internal.Lexer;
 import org.eclipse.xtext.ide.refactoring.IRenameStrategy2;
-import org.eclipse.xtext.ide.server.rename.IRenameService;
-import org.eclipse.xtext.ide.server.rename.RenameService;
+import org.eclipse.xtext.ide.server.rename.IRenameService2;
+import org.eclipse.xtext.ide.server.rename.RenameService2;
 import org.eclipse.xtext.xbase.ide.DefaultXbaseIdeModule;
 import uk.ac.kcl.inf.mdeoptimiser.languages.ide.contentassist.antlr.MoptParser;
 import uk.ac.kcl.inf.mdeoptimiser.languages.ide.contentassist.antlr.internal.InternalMoptLexer;
@@ -48,8 +48,8 @@ public abstract class AbstractMoptIdeModule extends DefaultXbaseIdeModule {
 	}
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ui.refactoring.RefactorElementNameFragment2
-	public Class<? extends IRenameService> bindIRenameService() {
-		return RenameService.class;
+	public Class<? extends IRenameService2> bindIRenameService2() {
+		return RenameService2.class;
 	}
 	
 	// contributed by org.eclipse.xtext.xtext.generator.ui.refactoring.RefactorElementNameFragment2

--- a/languages/mopt/xtext/.flattened-pom.xml
+++ b/languages/mopt/xtext/.flattened-pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext</groupId>

--- a/languages/mopt/xtext/.flattened-pom.xml
+++ b/languages/mopt/xtext/.flattened-pom.xml
@@ -19,8 +19,15 @@
       <url>http://nexus.codehaus.org/snapshots/</url>
     </repository>
     <repository>
+      <id>p2.henshin.repository</id>
+      <url>https://download.eclipse.org/modeling/emft/henshin/updates/release</url>
+    </repository>
+    <repository>
+      <releases>
+        <updatePolicy>always</updatePolicy>
+      </releases>
       <id>p2.eclipse.repository</id>
-      <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2019-03/final/</url>
+      <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2025-03/final/</url>
     </repository>
     <repository>
       <id>m2.moeaframework</id>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.classpath
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.classpath
@@ -26,7 +26,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src/main/xtext-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.classpath
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.classpath
@@ -26,7 +26,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="src/main/xtext-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
 		<attributes>
 			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext</groupId>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
@@ -9,38 +9,38 @@
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.testing</artifactId>
-      <version>2.17.0</version>
+      <version>2.38.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.testing</artifactId>
-      <version>2.17.0</version>
+      <version>2.38.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext</artifactId>
-      <version>2.17.0</version>
+      <version>2.38.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase</artifactId>
-      <version>2.17.0</version>
+      <version>2.38.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xtext.generator</artifactId>
-      <version>2.17.0</version>
+      <version>2.38.0</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-      <version>2.10.0</version>
+      <version>2.21.0</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/.flattened-pom.xml
@@ -65,8 +65,15 @@
       <url>http://nexus.codehaus.org/snapshots/</url>
     </repository>
     <repository>
+      <id>p2.henshin.repository</id>
+      <url>https://download.eclipse.org/modeling/emft/henshin/updates/release</url>
+    </repository>
+    <repository>
+      <releases>
+        <updatePolicy>always</updatePolicy>
+      </releases>
       <id>p2.eclipse.repository</id>
-      <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2019-03/final/</url>
+      <url>https://mde-optimiser.github.io/mdeo_repo/repository/m2/eclipse/2025-03/final/</url>
     </repository>
     <repository>
       <id>m2.moeaframework</id>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/jar-with-ecore-model.xml
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/jar-with-ecore-model.xml
@@ -8,12 +8,12 @@
 	<includeBaseDirectory>false</includeBaseDirectory>
 	<fileSets>
 		<fileSet>
-			<outputDirectory>/</outputDirectory>
 			<directory>target/classes</directory>
+			<outputDirectory>./</outputDirectory>
 		</fileSet>
 		<fileSet>
-			<outputDirectory>model/generated</outputDirectory>
 			<directory>model/generated</directory>
+			<outputDirectory>model/generated</outputDirectory>
 		</fileSet>
 	</fileSets>
 </assembly>

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/main/resources/META-INF/MANIFEST.MF
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/main/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext
 Bundle-SymbolicName: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages,
  uk.ac.kcl.inf.mdeoptimiser.languages.jvmmodel,

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/main/resources/META-INF/MANIFEST.MF
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/main/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext
 Bundle-SymbolicName: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages,
  uk.ac.kcl.inf.mdeoptimiser.languages.jvmmodel,

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/test/resources/META-INF/MANIFEST.MF
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/test/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext
 Bundle-SymbolicName: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.tests;x-internal=true
 Require-Bundle: org.eclipse.xtext.testing,

--- a/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/test/resources/META-INF/MANIFEST.MF
+++ b/languages/mopt/xtext/uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext/src/test/resources/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext
 Bundle-SymbolicName: uk.ac.kcl.inf.mdeoptimiser.languages.mopt.xtext;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.kcl.inf.mdeoptimiser.languages.tests;x-internal=true
 Require-Bundle: org.eclipse.xtext.testing,

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -35,8 +35,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.source}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -123,12 +123,12 @@
 		<dependency>
 			<groupId>org.eclipse.ocl</groupId>
 			<artifactId>org.eclipse.ocl</artifactId>
-			<version>3.10.200</version>
+			<version>3.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.ocl</groupId>
 			<artifactId>org.eclipse.ocl.ecore</artifactId>
-			<version>3.10.200</version>
+			<version>3.22.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.mifmif</groupId>
@@ -138,7 +138,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.ecore</artifactId>
-			<version>2.15.0</version>
+			<version>2.38.0</version>
 		</dependency>
 		<!-- This is required by henshin operators that have trace rules -->
 		<dependency>

--- a/libraries/core/pom.xml
+++ b/libraries/core/pom.xml
@@ -112,13 +112,13 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.henshin.interpreter</artifactId>
-			<version>1.7.0</version>
+			<version>1.8.0</version>
 		</dependency>
         <!--CPA Dependency -->
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.henshin.multicda.cpa</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0</version>
         </dependency>
 		<dependency>
 			<groupId>org.eclipse.ocl</groupId>
@@ -144,7 +144,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.henshin.trace</artifactId>
-			<version>1.7.0</version>
+			<version>1.8.0</version>
 		</dependency>
 		<!-- System information -->
 		<dependency>

--- a/libraries/core/src/main/java/uk/ac/kcl/inf/mdeoptimiser/libraries/core/optimisation/interpreter/guidance/ocl/OclGuidanceFunctionsFactory.java
+++ b/libraries/core/src/main/java/uk/ac/kcl/inf/mdeoptimiser/libraries/core/optimisation/interpreter/guidance/ocl/OclGuidanceFunctionsFactory.java
@@ -14,7 +14,7 @@ import uk.ac.kcl.inf.mdeoptimiser.libraries.core.optimisation.interpreter.guidan
 public class OclGuidanceFunctionsFactory implements IGuidanceFunctionsFactory {
 
   static final OCL<?, EClassifier, ?, ?, ?, ?, ?, ?, ?, Constraint, EClass, EObject>
-      oclInterpreter = OCL.newInstance(EcoreEnvironmentFactory.INSTANCE);
+      oclInterpreter = OCL.newInstanceAbstract(EcoreEnvironmentFactory.INSTANCE);
   static final OCLHelper<EClassifier, ?, ?, Constraint> oclHelper =
       oclInterpreter.createOCLHelper();
 

--- a/libraries/rulegen/pom.xml
+++ b/libraries/rulegen/pom.xml
@@ -20,8 +20,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.source}</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/libraries/rulegen/pom.xml
+++ b/libraries/rulegen/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.henshin.model</artifactId>
-			<version>1.7.0</version>
+			<version>1.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.sidiff.serge</groupId>
@@ -110,13 +110,19 @@
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.testing</artifactId>
-			<version>${xtend.version}</version>
+			<version>${xtextVersion}</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.hamcrest/java-hamcrest -->
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>java-hamcrest</artifactId>
 			<version>2.0.0.0</version>
+			<scope>test</scope>
+		</dependency> -->
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>3.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
PR to update all dependencies to make this work with latest Eclipse.

Things still to do:

- [x] Consistency: some bits have been updated to depend on JDK 17 and others to 21. This should be made consistent.
- [x] Ensure examples reference correct versions of various plugins
  - [x] Including updating the dynemf dependencies -- consider feeding this back to original repository, too
- [x] Ensure plugin versions in update site are consistent with what is being used via maven
- [x] Update version of MOEA Framework -- devolved to #126 